### PR TITLE
打印处理进度百分比信息

### DIFF
--- a/src/realcugan.cpp
+++ b/src/realcugan.cpp
@@ -704,6 +704,8 @@ int RealCUGAN::process(const ncnn::Mat& inimage, ncnn::Mat& outimage) const
                 cmd.submit_and_wait();
                 cmd.reset();
             }
+
+            fprintf(stderr, "%.2f%%\n", (float)(yi * xtiles + xi) / (ytiles * xtiles) * 100);
         }
 
         // download
@@ -1158,6 +1160,8 @@ int RealCUGAN::process_cpu(const ncnn::Mat& inimage, ncnn::Mat& outimage) const
 #endif
                 }
             }
+
+            fprintf(stderr, "%.2f%%\n", (float)(yi * xtiles + xi) / (ytiles * xtiles) * 100);
         }
     }
 
@@ -2071,6 +2075,9 @@ int RealCUGAN::process_se_stage2(const ncnn::Mat& inimage, const std::vector<std
                 cmd.submit_and_wait();
                 cmd.reset();
             }
+
+
+            fprintf(stderr, "%.2f%%\n", (float)(yi * xtiles + xi) / (ytiles * xtiles) * 100);
         }
 
         // download
@@ -3361,6 +3368,9 @@ int RealCUGAN::process_cpu_se_stage2(const ncnn::Mat& inimage, const std::vector
 #endif
                 }
             }
+
+
+            fprintf(stderr, "%.2f%%\n", (float)(yi * xtiles + xi) / (ytiles * xtiles) * 100);
         }
     }
 


### PR DESCRIPTION
因为目前没有打印进度百分比，在等待处理时难以预估进度和事件。
我对realcugan的处理事件进行分析后，发现主要耗时在stage2阶段。
因此针对几种stage2阶段的函数，增加了打印进度百分比的信息（可以近似看作整体处理进度）