### PR TITLE
Fix Visual Studio build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Visual Studio
+src/.vs
+src/out
+
+# Command line CMake
+build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 project(realcugan-ncnn-vulkan)
 
 cmake_minimum_required(VERSION 3.9)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE release CACHE STRING "Choose the type of build" FORCE)


### PR DESCRIPTION
- Added `CMAKE_POLICY_VERSION_MINIMUM` to allow building with Visual Studio 2026
- Added `.gitignore` file with default Visual Studio build directories, as well as the build folder from repo's build instructions.